### PR TITLE
Removed property type hints for PHP 7.3 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4]
+        php: [8.0, 7.4, 7.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/Card.php
+++ b/src/Card.php
@@ -15,7 +15,7 @@ class Card implements Arrayable
      *
      * @var array
      */
-    protected array $payload = [
+    protected $payload = [
         'sections' => [],
     ];
 

--- a/src/Components/Button/AbstractButton.php
+++ b/src/Components/Button/AbstractButton.php
@@ -12,7 +12,7 @@ abstract class AbstractButton implements Arrayable
      *
      * @var array
      */
-    protected array $payload = [];
+    protected $payload = [];
 
     /**
      * Set the onClick url.

--- a/src/GoogleChatMessage.php
+++ b/src/GoogleChatMessage.php
@@ -15,14 +15,14 @@ class GoogleChatMessage implements Arrayable
      *
      * @var array
      */
-    protected array $payload = [];
+    protected $payload = [];
 
     /**
      * The Space's webhook URL where this message should be sent.
      *
      * @var string|null
      */
-    protected ?string $endpoint = null;
+    protected $endpoint = null;
 
     /**
      * Set a specific space's webhook URL where this message should be sent to.

--- a/src/Section.php
+++ b/src/Section.php
@@ -16,7 +16,7 @@ class Section implements Arrayable
      *
      * @var array
      */
-    protected array $payload = [
+    protected $payload = [
         'widgets' => [],
     ];
 

--- a/src/Widgets/AbstractWidget.php
+++ b/src/Widgets/AbstractWidget.php
@@ -12,7 +12,7 @@ abstract class AbstractWidget implements Arrayable
      *
      * @var array
      */
-    protected array $payload = [];
+    protected $payload = [];
 
     /**
      * Serialize the widget to an array representation.


### PR DESCRIPTION
Per #4 this package was not truly compatible with PHP 7.3. This PR removed property type hints to become 7.3 compatible, as well as adds PHP 7.3 to the test matrix.

### Changed
- Removed property type hints

### Added
- PHP 7.3 to the test matrix