### PR TITLE
Upgrade to Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.1, 8.0]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `google-chat` will be documented in this file
 
+## 2.0.0 - 2022-02-12
+- Upgraded to support Laravel 9.x
+- Dropped support for PHP 7.3 and 7.4
+
 ## 1.0.1 - 2021-07-16
 - Removed property type hints for PHP 7.3 compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `google-chat` will be documented in this file
 
 ## 2.0.0 - 2022-02-12
-- Upgraded to support Laravel 9.x
+- Upgraded to support Laravel 9.x (Minimum of 9.0.2 due to an [unintended breaking change](https://github.com/laravel/framework/pull/40880))
 - Dropped support for PHP 7.3 and 7.4
 
 ## 1.0.1 - 2021-07-16

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 <a href="https://github.com/laravel-notification-channels/google-chat/actions?query=workflow%3A%22Check+%26+fix+styling%22+branch%3Amain"><img alt="GitHub Code Style Action" src="https://img.shields.io/github/workflow/status/laravel-notification-channels/google-chat/Check%20&%20fix%20styling/main?label=code%20style&style=flat-square"></a>
 <a href="https://packagist.org/packages/laravel-notification-channels/google-chat"><img alt="Total Downloads" src="https://img.shields.io/packagist/dt/laravel-notification-channels/google-chat.svg?style=flat-square"></a>
 <a href="composer.json"><img alt="PHP Version Requirements" src="https://img.shields.io/packagist/php-v/laravel-notification-channels/google-chat?style=flat-square"></a>
-<a href="composer.json"><img alt="Laravel Version Requirements" src="https://img.shields.io/badge/laravel-~8.0-gray?logo=laravel&style=flat-square&labelColor=F05340&logoColor=white"></a>
+<a href="composer.json"><img alt="Laravel Version Requirements" src="https://img.shields.io/badge/laravel-~9.0.2-gray?logo=laravel&style=flat-square&labelColor=F05340&logoColor=white"></a>
 </p>
 
 <h1>Google Chat - Laravel Notification Channel</h1>
 
-This package makes it easy to send notifications using [Google Chat](https://developers.google.com/hangouts/chat) , (formerly known as Hangouts Chat) with Laravel 8.x
+This package makes it easy to send notifications using [Google Chat](https://developers.google.com/hangouts/chat) , (formerly known as Hangouts Chat) with Laravel 9.x
 
 ````php
 class InvoicePaidNotification extends Notification
@@ -54,6 +54,7 @@ class InvoicePaidNotification extends Notification
 }
 ````
 
+> For Laravel 8.x, please use version 1.x of this package.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "~8.0",
-        "illuminate/support": "~8.0"
+        "illuminate/notifications": "~9.0",
+        "illuminate/support": "~9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.22",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "~9.0",
-        "illuminate/support": "~9.0"
+        "illuminate/notifications": "~9.0.2",
+        "illuminate/support": "~9.0.2"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",


### PR DESCRIPTION
This PR brings support for Laravel 9. Importantly, the PR also drops support for PHP 7.x.

Note that due to an [unintended breaking change](https://github.com/laravel/framework/pull/40880) in the framework, the minimum Laravel version required has been set to `9.0.2`.