### PR TITLE
Corrected Laravel framework version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `google-chat` will be documented in this file
 
+## 2.0.1 - 2022-04-09
+- Corrected Laravel Framework version constraints, preventing installations on Laravel versions >=9.1
+
 ## 2.0.0 - 2022-02-12
 - Upgraded to support Laravel 9.x (Minimum of 9.0.2 due to an [unintended breaking change](https://github.com/laravel/framework/pull/40880))
 - Dropped support for PHP 7.3 and 7.4

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "~9.0.2",
-        "illuminate/support": "~9.0.2"
+        "illuminate/notifications": "^9.0.2",
+        "illuminate/support": "^9.0.2"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",


### PR DESCRIPTION
Fix to correct Laravel version constraints, preventing package installation on Laravel version >=9.1