### PR TITLE
Fix toGoogleChat() passing a Notification instance, when it should pass a Notifiable class instead

### DIFF
--- a/src/GoogleChatChannel.php
+++ b/src/GoogleChatChannel.php
@@ -42,7 +42,7 @@ class GoogleChatChannel
         }
 
         /** @var \NotificationChannels\GoogleChat\GoogleChatMessage $message */
-        if (! ($message = $notification->toGoogleChat($notification)) instanceof GoogleChatMessage) {
+        if (! ($message = $notification->toGoogleChat($notifiable)) instanceof GoogleChatMessage) {
             throw CouldNotSendNotification::invalidMessage($message);
         }
 


### PR DESCRIPTION
Unlike other Laravel Notification Channel packages, this one appears to be passing an instance of the `Notification` to the `toGoogleChat()` method.

I think this is incorrect, as normally you should pass a `Notifiable` Model instance — so you can, for example, address a message with the user's name when writing the notification.

This is how it's already described in the docs, where the code samples specifically refer to it as `$notifiable`:

```php
public function toGoogleChat($notifiable)
{
    return GoogleChatMessage::create('Hello world!');
}
```

This PR simply swaps the variable to `$notifiable`. Thanks!