### PR TITLE
Fix #13 - Passing notification instead of notifiable

### DIFF
--- a/src/GoogleChatChannel.php
+++ b/src/GoogleChatChannel.php
@@ -42,7 +42,7 @@ class GoogleChatChannel
         }
 
         /** @var \NotificationChannels\GoogleChat\GoogleChatMessage $message */
-        if (! ($message = $notification->toGoogleChat($notification)) instanceof GoogleChatMessage) {
+        if (! ($message = $notification->toGoogleChat($notifiable)) instanceof GoogleChatMessage) {
             throw CouldNotSendNotification::invalidMessage($message);
         }
 

--- a/tests/GoogleChatChannelTest.php
+++ b/tests/GoogleChatChannelTest.php
@@ -25,18 +25,19 @@ class GoogleChatChannelTest extends TestCase
         $this->newChannel()->send('foo', $notification);
     }
 
+    /** @group focus */
     public function test_it_rejects_sending_when_non_google_chat_message_supplied()
     {
         $notification = $this->createMock(TestNotification::class);
         $notification->expects($this->once())
         ->method('toGoogleChat')
-        ->withAnyParameters()
+        ->with('notifiable')
         ->willReturn('This value is invalid, as it is not an instance of Google Chat Message');
 
         $this->expectException(CouldNotSendNotification::class);
         $this->expectExceptionMessage("Expected a message instance of type NotificationChannels\GoogleChat\GoogleChatMessage - Actually received string");
 
-        $this->newChannel()->send('foo', $notification);
+        $this->newChannel()->send('notifiable', $notification);
     }
 
     public function test_it_rejects_sending_when_no_space_configured()

--- a/tests/GoogleChatChannelTest.php
+++ b/tests/GoogleChatChannelTest.php
@@ -25,7 +25,6 @@ class GoogleChatChannelTest extends TestCase
         $this->newChannel()->send('foo', $notification);
     }
 
-    /** @group focus */
     public function test_it_rejects_sending_when_non_google_chat_message_supplied()
     {
         $notification = $this->createMock(TestNotification::class);


### PR DESCRIPTION
- Corrected `GoogleChatChannel::send()` to pass an instance of notifiable to the notification's `toGoogleChat()` method
- Updated `GoogleChatChannelTest` to expect the notifiable instance is passed to the `toGoogleChat()` method

Resolves and closes #13. Though this is fixes an incorrect implementation, it is unfortunately a breaking change, so will release as a new major version 3.x