### PR TITLE
Feature/message replies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.2, 8.1]
+                php: [8.5, 8.4, 8.3, 8.2, 8.1]
                 stability: [prefer-lowest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The `GoogleChatMessage` class encompasses an entire message that will be sent to
 
 - `static create(?string $text)` Instantiates and returns a new `GoogleChatMessage` instance, optionally pre-configuring it with the provided simple text
 - `to(string $space)` Specifies the webhook or space key this notification will be sent to. This takes precedence over the default space and any value returned by a notifiable's `routeNotificationForGoogleChat()` method
+- `thread(string $thread)` Start or reply to a message thread (in supported spaces)
 - `text(string $message)` Appends `$message` to the simple message content
 - `line(string $message)` Appends `$message` on a new line
 - `bold(string $message)` Appends bold text
@@ -428,6 +429,12 @@ The `ImageButton` defines a clickable icon or image, and can be accepted anywher
 - `static create(?string $url, ?string $icon)` Instantiates and returns a new `ImageButton` instance, optionally pre-configuring it with the provided URL and icon
 - `url(string $url)` Defines the target endpoint for the button
 - `icon(string $icon)` Defines the icon or image to display for the button.
+
+### Message Threads
+
+If you are posting into a space that supports [conversation by topic](https://support.google.com/mail/answer/12176488) you may set a known thread key in order to reply to a specific message thread. Using a new/unrecognized key will automatically begin a new message thread within the space which may be replied to later by using that same key again.
+
+By default the reference will be passed as a threadKey which is the most common requirement. Adding `true` as a second parameter in `thread('my_thread_ref', true)` will pass it as a thread name instead. Refer to the [Chat API](https://developers.google.com/chat/api/guides/crudl/messages#start_or_reply_to_a_message_thread) for more details.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 <a href="https://github.com/laravel-notification-channels/google-chat/actions?query=workflow%3A%22Check+%26+fix+styling%22+branch%3Amain"><img alt="GitHub Code Style Action" src="https://img.shields.io/github/workflow/status/laravel-notification-channels/google-chat/Check%20&%20fix%20styling/main?label=code%20style&style=flat-square"></a>
 <a href="https://packagist.org/packages/laravel-notification-channels/google-chat"><img alt="Total Downloads" src="https://img.shields.io/packagist/dt/laravel-notification-channels/google-chat.svg?style=flat-square"></a>
 <a href="composer.json"><img alt="PHP Version Requirements" src="https://img.shields.io/packagist/php-v/laravel-notification-channels/google-chat?style=flat-square"></a>
-<a href="composer.json"><img alt="Laravel Version Requirements" src="https://img.shields.io/badge/laravel-~9.0.2-gray?logo=laravel&style=flat-square&labelColor=F05340&logoColor=white"></a>
+<a href="composer.json"><img alt="Laravel Version Requirements" src="https://img.shields.io/badge/laravel-9.x--13.x-gray?logo=laravel&style=flat-square&labelColor=F05340&logoColor=white"></a>
 </p>
 
 <h1>Google Chat - Laravel Notification Channel</h1>
 
-This package makes it easy to send notifications using [Google Chat](https://developers.google.com/hangouts/chat) , (formerly known as Hangouts Chat) with Laravel 9.x
+This package makes it easy to send notifications using [Google Chat](https://developers.google.com/hangouts/chat) , (formerly known as Hangouts Chat) with Laravel 9.x to 13.x
 
 ````php
 class InvoicePaidNotification extends Notification

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "^9.0.2 || ^10.0",
-        "illuminate/support": "^9.0.2 || ^10.0"
+        "illuminate/notifications": "^9.0.2 || ^10.0 || ^11.0",
+        "illuminate/support": "^9.0.2 || ^10.0 || ^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
-        "phpunit/phpunit": "^9.5.10"
+        "orchestra/testbench": "^7.0 || ^9.0",
+        "phpunit/phpunit": "^9.5.10 || ^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "^9.0.2 || ^10.0 || ^11.0",
-        "illuminate/support": "^9.0.2 || ^10.0 || ^11.0"
+        "illuminate/notifications": "^9.0.2 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^9.0.2 || ^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0 || ^9.0",
-        "phpunit/phpunit": "^9.5.10 || ^10.5"
+        "orchestra/testbench": "^7.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^9.5.10 || ^10.5 || ^11.5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "require": {
         "php": ">=8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "illuminate/notifications": "^9.0.2 || ^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^9.0.2 || ^10.0 || ^11.0 || ^12.0"
+        "illuminate/notifications": "^9.0.2 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^9.0.2 || ^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^7.0 || ^9.0 || ^10.0 || ^11.0",
         "phpunit/phpunit": "^9.5.10 || ^10.5 || ^11.5.3"
     },
     "autoload": {

--- a/src/GoogleChatChannel.php
+++ b/src/GoogleChatChannel.php
@@ -54,6 +54,10 @@ class GoogleChatChannel
             throw CouldNotSendNotification::webhookUnavailable();
         }
 
+        if ($message->isThreaded()) {
+            $endpoint .= '&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD';
+        }
+
         try {
             $this->client->request(
                 'post',

--- a/src/GoogleChatMessage.php
+++ b/src/GoogleChatMessage.php
@@ -213,6 +213,32 @@ class GoogleChatMessage implements Arrayable
     }
 
     /**
+     * Start or reply to a message thread.
+     *
+     * @param string $thread A thread reference that can be reused later to add replies
+     * @param bool $isName Specify the thread using a name rather than a threadKey (not typically wanted)
+     * @return self
+     */
+    public function thread(string $thread, bool $isName = false): GoogleChatMessage
+    {
+        $this->payload['thread'] = [
+            $isName ? 'name' : 'threadKey' => $thread,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * The message is creating or replying to a message thread.
+     *
+     * @return bool
+     */
+    public function isThreaded(): bool
+    {
+        return isset($this->payload['thread']);
+    }
+
+    /**
      * Return the configured webhook URL of the recipient space, or null if this has
      * not been configured.
      *

--- a/tests/GoogleChatChannelTest.php
+++ b/tests/GoogleChatChannelTest.php
@@ -229,7 +229,7 @@ class GoogleChatChannelTest extends TestCase
         return new TestNotification;
     }
 
-    private function newNotifiable(string $space = null): TestNotifiable
+    private function newNotifiable(?string $space = null): TestNotifiable
     {
         return new TestNotifiable($space);
     }

--- a/tests/GoogleChatMessageTest.php
+++ b/tests/GoogleChatMessageTest.php
@@ -205,4 +205,44 @@ class GoogleChatMessageTest extends TestCase
             $message->toArray()
         );
     }
+
+    public function test_it_creates_threaded_messages_by_key()
+    {
+        $message = GoogleChatMessage::create()->thread('test-thread-key');
+
+        $this->assertEquals(
+            [
+                'thread' => [
+                    'threadKey' => 'test-thread-key',
+                ],
+            ],
+            $message->toArray()
+        );
+    }
+
+    public function test_it_creates_threaded_messages_by_name()
+    {
+        $message = GoogleChatMessage::create()->thread('test-thread-name', true);
+
+        $this->assertEquals(
+            [
+                'thread' => [
+                    'name' => 'test-thread-name',
+                ],
+            ],
+            $message->toArray()
+        );
+    }
+
+    public function test_it_recognises_non_threaded_messages()
+    {
+        $message = GoogleChatMessage::create('Example Non-Threaded Message');
+        $this->assertFalse($message->isThreaded());
+    }
+
+    public function test_it_recognises_threaded_messages()
+    {
+        $message = GoogleChatMessage::create('Example Threaded Message')->thread('test-thread-key');
+        $this->assertTrue($message->isThreaded());
+    }
 }


### PR DESCRIPTION
Adds support for message threads so replies can be grouped together in spaces that support threading. The addition does not break/change any existing functionality.

API spec: https://developers.google.com/chat/api/guides/crudl/messages#start_or_reply_to_a_message_thread

It's very useful functionality when an initial notification is later followed up with a separate one for the issue's resolution. In this case the two messages can be grouped together for context along with any conversation that other chat members have had in between the two.