### PR TITLE
Fix: declare $message as nullable (?string) to match default null

### DIFF
--- a/src/Card.php
+++ b/src/Card.php
@@ -28,7 +28,7 @@ class Card implements Arrayable
      * @param string|null $imageStyle Configure the avatar image style, one of IMAGE or AVATAR
      * @return self
      */
-    public function header(string $title, string $subtitle = null, string $imageUrl = null, string $imageStyle = null): Card
+    public function header(string $title, ?string $subtitle = null, ?string $imageUrl = null, ?string $imageStyle = null): Card
     {
         $header = [
             'title' => $title,

--- a/src/Components/Button/ImageButton.php
+++ b/src/Components/Button/ImageButton.php
@@ -54,7 +54,7 @@ class ImageButton extends AbstractButton
      * @param string|null $icon Either an icon name or URL to the icon image
      * @return self
      */
-    public static function create(string $url = null, string $icon = null): ImageButton
+    public static function create(?string $url = null, ?string $icon = null): ImageButton
     {
         $button = new static;
 

--- a/src/Components/Button/TextButton.php
+++ b/src/Components/Button/TextButton.php
@@ -24,7 +24,7 @@ class TextButton extends AbstractButton
      * @param string|null $displayText
      * @return self
      */
-    public static function create(string $url = null, string $displayText = null): TextButton
+    public static function create(?string $url = null, ?string $displayText = null): TextButton
     {
         $button = new static;
 

--- a/src/GoogleChatMessage.php
+++ b/src/GoogleChatMessage.php
@@ -157,7 +157,7 @@ class GoogleChatMessage implements Arrayable
      * @param string|null $displayText
      * @return self
      */
-    public function link(string $link, string $displayText = null): GoogleChatMessage
+    public function link(string $link, ?string $displayText = null): GoogleChatMessage
     {
         if ($displayText) {
             $link = "<{$link}|{$displayText}>";
@@ -188,7 +188,7 @@ class GoogleChatMessage implements Arrayable
      * @param string|null $appendText
      * @return self
      */
-    public function mentionAll(string $prependText = null, string $appendText = null): GoogleChatMessage
+    public function mentionAll(string $prependText = null, ?string $appendText = null): GoogleChatMessage
     {
         $this->text("{$prependText}<users/all>{$appendText}");
 
@@ -262,7 +262,7 @@ class GoogleChatMessage implements Arrayable
      * @param string|null $text
      * @return self
      */
-    public static function create(string $text = null): GoogleChatMessage
+    public static function create(?string $text = null): GoogleChatMessage
     {
         $message = new static;
 

--- a/src/Widgets/Image.php
+++ b/src/Widgets/Image.php
@@ -41,7 +41,7 @@ class Image extends AbstractWidget
      * @param string|null $onClickUrl
      * @return self
      */
-    public static function create(string $imageUrl = null, string $onClickUrl = null): Image
+    public static function create(?string $imageUrl = null, ?string $onClickUrl = null): Image
     {
         $widget = new static;
 

--- a/src/Widgets/KeyValue.php
+++ b/src/Widgets/KeyValue.php
@@ -109,7 +109,7 @@ class KeyValue extends AbstractWidget
      * @param string|null $bottomLabel
      * @return self
      */
-    public static function create(string $topLabel = null, string $content = null, string $bottomLabel = null): KeyValue
+    public static function create(?string $topLabel = null, ?string $content = null, ?string $bottomLabel = null): KeyValue
     {
         $widget = new static;
 

--- a/src/Widgets/TextParagraph.php
+++ b/src/Widgets/TextParagraph.php
@@ -91,7 +91,7 @@ class TextParagraph extends AbstractWidget
      * @param string|null $displayText
      * @return self
      */
-    public function link(string $link, string $displayText = null): TextParagraph
+    public function link(string $link, ?string $displayText = null): TextParagraph
     {
         return $this->text("<a href=\"{$link}\">".($displayText ?? $link).'</a>');
     }
@@ -112,7 +112,7 @@ class TextParagraph extends AbstractWidget
      * @param string|null $message
      * @return self
      */
-    public static function create(string $message = null): TextParagraph
+    public static function create(?string $message = null): TextParagraph
     {
         $widget = new static;
 


### PR DESCRIPTION
### what i have done

The parameter had a default null but a non-nullable string type, causing static analysis warnings and potential type errors. This PR changes it to ?string. No functional behavior changes.